### PR TITLE
sampler: honor active BQ sampling budgets

### DIFF
--- a/proeval/sampler/bq.py
+++ b/proeval/sampler/bq.py
@@ -260,36 +260,42 @@ def _bq_active_sampling(
     
     true_prior_integral_var = np.sum(S) / (n_samples * n_samples)
     integral_variance = np.ones(budget) * true_prior_integral_var
-    k_t_inv = None
     mu_x = np.mean(test_x, axis=1, keepdims=True)
 
+    # Keep the rank-1 acquisition state aligned with any random initial points.
+    if labeled_indices:
+        train_x_init = test_x[:, labeled_indices]
+        k_t_inv = np.linalg.inv(
+            np.dot(train_x_init, train_x_init.T) / noise_variance
+            + np.eye(test_x.shape[0])
+        )
+    else:
+        k_t_inv = None
+
     for t in range(n_init, budget):
+        # Acquire first so estimates[t] represents the posterior after t + 1
+        # actual target evaluations. The zero-sample state remains available
+        # separately through result.prior_mean.
+        train_x_t = test_x[:, labeled_indices]
+        best_idx, k_t_inv = _variance_improvement(
+            train_x_t, k_t_inv, noise_variance, unlabeled_indices, test_x
+        )
+        labeled_indices.append(best_idx)
+        unlabeled_indices.remove(best_idx)
+
         train_x_t = test_x[:, labeled_indices]
         train_y_t = test_y[labeled_indices]
-
-        if t == 0:
-            u_t = u
-            int_var_t = true_prior_integral_var
-        else:
-            u_t, s_t = _get_posterior(
-                train_x_t, train_y_t, test_x, noise_variance, labeled_indices, u
-            )
-            _, s_mu = _get_posterior(
-                train_x_t, train_y_t, mu_x, noise_variance, labeled_indices, u
-            )
-            int_var_t = s_mu[0]
+        u_t, _ = _get_posterior(
+            train_x_t, train_y_t, test_x, noise_variance, labeled_indices, u
+        )
+        _, s_mu = _get_posterior(
+            train_x_t, train_y_t, mu_x, noise_variance, labeled_indices, u
+        )
 
         rounded_estimates[t] = np.mean(np.round(u_t))
         estimates[t] = np.mean(u_t)
         # Integral variance is variance of the mean
-        integral_variance[t] = np.maximum(int_var_t, 0.0)
-
-        if t < budget - 1:
-            best_idx, k_t_inv = _variance_improvement(
-                train_x_t, k_t_inv, noise_variance, unlabeled_indices, test_x
-            )
-            labeled_indices.append(best_idx)
-            unlabeled_indices.remove(best_idx)
+        integral_variance[t] = np.maximum(s_mu[0], 0.0)
 
     # Back-fill initial steps
     for t in range(n_init):
@@ -543,29 +549,34 @@ def _bq_matern_active_sampling(
     rounded_estimates = np.ones(budget) * np.mean(np.round(np.clip(u, 0, 1)))
     integral_variance = np.ones(budget) * 1.0
 
-    for t in range(n_init, budget):
-        if t == 0:
-            u_t = u.copy()
-            posterior_cov = _compute_matern_kernel_np(emb_norm, lengthscale=lengthscale, nu=nu)
-        else:
-            u_t, posterior_cov = _get_posterior_matern(
-                emb_norm[labeled_indices], test_y[labeled_indices],
-                emb_norm, noise_variance, labeled_indices, u,
-                lengthscale=lengthscale, nu=nu, full_cov=True,
-            )
+    if labeled_indices:
+        _, posterior_cov = _get_posterior_matern(
+            emb_norm[labeled_indices], test_y[labeled_indices],
+            emb_norm, noise_variance, labeled_indices, u,
+            lengthscale=lengthscale, nu=nu, full_cov=True,
+        )
+    else:
+        posterior_cov = _compute_matern_kernel_np(
+            emb_norm, lengthscale=lengthscale, nu=nu
+        )
 
+    for t in range(n_init, budget):
+        best_idx = _variance_improvement_gp(
+            posterior_cov, unlabeled_indices, noise_variance,
+        )
+        labeled_indices.append(best_idx)
+        unlabeled_indices.remove(best_idx)
+
+        u_t, posterior_cov = _get_posterior_matern(
+            emb_norm[labeled_indices], test_y[labeled_indices],
+            emb_norm, noise_variance, labeled_indices, u,
+            lengthscale=lengthscale, nu=nu, full_cov=True,
+        )
         estimates[t] = np.mean(u_t)
         rounded_estimates[t] = np.mean(np.round(np.clip(u_t, 0, 1)))
         integral_variance[t] = np.maximum(
             np.sum(posterior_cov) / (n_samples * n_samples), 0.0
         )
-
-        if t < budget - 1:
-            best_idx = _variance_improvement_gp(
-                posterior_cov, unlabeled_indices, noise_variance,
-            )
-            labeled_indices.append(best_idx)
-            unlabeled_indices.remove(best_idx)
 
     # Back-fill init steps
     for t in range(n_init):
@@ -848,35 +859,41 @@ def _bq_encoder_sampling(
     use_gp_path = (kernel_type != "linear")
 
     if use_gp_path:
-        # Matérn / RBF path: maintain full posterior covariance
-        for t in range(n_init, budget):
-            if t == 0:
-                u_t = u.copy()
-                # Prior covariance from encoder kernel
-                phi_t = torch.from_numpy(phi_embeddings).float().to(device)
-                posterior_cov = compute_kernel_matrix(
-                    phi_t, encoder
-                ).detach().cpu().numpy()
-            else:
-                phi_train = phi_embeddings[labeled_indices]
-                u_t, posterior_cov = get_posterior_embedding(
-                    phi_train, test_y[labeled_indices],
-                    phi_embeddings, noise_variance,
-                    labeled_indices, u, encoder, device,
-                    full_cov=True,
-                )
+        # Matérn / RBF path: maintain full posterior covariance.
+        if labeled_indices:
+            phi_train = phi_embeddings[labeled_indices]
+            _, posterior_cov = get_posterior_embedding(
+                phi_train, test_y[labeled_indices],
+                phi_embeddings, noise_variance,
+                labeled_indices, u, encoder, device,
+                full_cov=True,
+            )
+        else:
+            phi_t = torch.from_numpy(phi_embeddings).float().to(device)
+            posterior_cov = compute_kernel_matrix(
+                phi_t, encoder
+            ).detach().cpu().numpy()
 
+        for t in range(n_init, budget):
+            best_idx = _variance_improvement_gp(
+                posterior_cov, unlabeled_indices, noise_variance,
+            )
+            labeled_indices.append(best_idx)
+            unlabeled_indices.remove(best_idx)
+
+            phi_train = phi_embeddings[labeled_indices]
+            u_t, posterior_cov = get_posterior_embedding(
+                phi_train, test_y[labeled_indices],
+                phi_embeddings, noise_variance,
+                labeled_indices, u, encoder, device,
+                full_cov=True,
+            )
             estimates[t] = np.mean(u_t)
             rounded_estimates[t] = np.mean(np.round(np.clip(u_t, 0, 1)))
             # Integral variance from full posterior covariance
-            integral_variance[t] = np.maximum(np.sum(posterior_cov) / (n_samples * n_samples), 0.0)
-
-            if t < budget - 1:
-                best_idx = _variance_improvement_gp(
-                    posterior_cov, unlabeled_indices, noise_variance,
-                )
-                labeled_indices.append(best_idx)
-                unlabeled_indices.remove(best_idx)
+            integral_variance[t] = np.maximum(
+                np.sum(posterior_cov) / (n_samples * n_samples), 0.0
+            )
 
         # Back-fill initial steps
         for t in range(n_init):
@@ -905,41 +922,40 @@ def _bq_encoder_sampling(
     else:
         # Linear kernel path: use fast rank-1 update
         test_x = phi_embeddings.T  # (d, m)
-        k_t_inv = None
         mu_x = np.mean(test_x, axis=1, keepdims=True)
 
-        # compute prior mean_var properly
-        prior_cov_sum = np.dot(np.dot(mu_x.T, np.eye(test_x.shape[0])), mu_x)[0, 0]
+        if labeled_indices:
+            train_x_init = test_x[:, labeled_indices]
+            k_t_inv = np.linalg.inv(
+                np.dot(train_x_init, train_x_init.T) / noise_variance
+                + np.eye(test_x.shape[0])
+            )
+        else:
+            k_t_inv = None
 
         for t in range(n_init, budget):
             train_x = test_x[:, labeled_indices] if labeled_indices else test_x[:, []]
-            train_y_arr = test_y[labeled_indices] if labeled_indices else np.array([])
+            best_idx, k_t_inv = _variance_improvement(
+                train_x, k_t_inv, noise_variance,
+                unlabeled_indices, test_x,
+            )
+            labeled_indices.append(best_idx)
+            unlabeled_indices.remove(best_idx)
 
-            if t == 0:
-                u_t = u.copy()
-                int_var_t = prior_cov_sum  # prior variance
-            else:
-                u_t, s_t = _get_posterior(
-                    train_x, train_y_arr, test_x,
-                    noise_variance, labeled_indices, u,
-                )
-                _, s_mu = _get_posterior(
-                    train_x, train_y_arr, mu_x,
-                    noise_variance, labeled_indices, u,
-                )
-                int_var_t = s_mu[0]
+            train_x = test_x[:, labeled_indices]
+            train_y_arr = test_y[labeled_indices]
+            u_t, _ = _get_posterior(
+                train_x, train_y_arr, test_x,
+                noise_variance, labeled_indices, u,
+            )
+            _, s_mu = _get_posterior(
+                train_x, train_y_arr, mu_x,
+                noise_variance, labeled_indices, u,
+            )
 
             estimates[t] = np.mean(u_t)
             rounded_estimates[t] = np.mean(np.round(np.clip(u_t, 0, 1)))
-            integral_variance[t] = np.maximum(int_var_t, 0.0)
-
-            if t < budget - 1:
-                best_idx, k_t_inv = _variance_improvement(
-                    train_x, k_t_inv, noise_variance,
-                    unlabeled_indices, test_x,
-                )
-                labeled_indices.append(best_idx)
-                unlabeled_indices.remove(best_idx)
+            integral_variance[t] = np.maximum(s_mu[0], 0.0)
 
         # Back-fill initial steps
         for t in range(n_init):

--- a/proeval/sampler/bq.py
+++ b/proeval/sampler/bq.py
@@ -228,6 +228,18 @@ def _variance_improvement_gp(
 
 
 # Core BQ sampling loop
+
+
+def _validate_active_sampling_budget(
+    n_init: int, budget: int, n_samples: int
+) -> None:
+    """Validate active-sampling budget bounds before sampling."""
+    if not 0 <= n_init <= budget <= n_samples:
+        raise ValueError(
+            "expected 0 <= n_init <= budget <= n_samples; "
+            f"got n_init={n_init}, budget={budget}, n_samples={n_samples}"
+        )
+
 def _bq_active_sampling(
     test_x: np.ndarray,
     test_y: np.ndarray,
@@ -243,6 +255,7 @@ def _bq_active_sampling(
     step, the acquisition-order indices, and the final posterior.
     """
     n_samples = test_x.shape[1]
+    _validate_active_sampling_budget(n_init, budget, n_samples)
 
     # Optional random initialisation from "interesting" prior range
     good_indices = [i for i in range(len(u)) if 0.2 < u[i] < 0.6]
@@ -533,6 +546,7 @@ def _bq_matern_active_sampling(
     # Normalize embeddings
     emb_norm = embeddings / (np.linalg.norm(embeddings, axis=1, keepdims=True) + 1e-10)
     n_samples = emb_norm.shape[0]
+    _validate_active_sampling_budget(n_init, budget, n_samples)
 
     # Optional random initialisation
     good_indices = [i for i in range(n_samples) if 0.2 < u[i] < 0.6]
@@ -838,6 +852,7 @@ def _bq_encoder_sampling(
 
     kernel_type = getattr(encoder, "kernel_type", "linear")
     n_samples = phi_embeddings.shape[0]
+    _validate_active_sampling_budget(n_init, budget, n_samples)
 
     # Optional random initialisation from "interesting" prior range
     good_indices = [i for i in range(n_samples) if 0.2 < u[i] < 0.6]

--- a/tests/test_bq_sampling.py
+++ b/tests/test_bq_sampling.py
@@ -176,3 +176,26 @@ def test_active_estimates_are_post_sample_posteriors():
     assert result.estimates[0] == pytest.approx(np.mean(first_posterior))
     assert result.estimates[-1] == pytest.approx(np.mean(final_posterior))
     np.testing.assert_allclose(result.posterior_mean, final_posterior)
+
+
+@pytest.mark.parametrize("kind", ["sf", "rpf", "tpf"])
+def test_active_sampling_rejects_n_init_above_budget(kind):
+    with pytest.raises(ValueError, match="0 <= n_init <= budget <= n_samples"):
+        _run_active(kind, budget=2, n_init=3)
+
+
+@pytest.mark.parametrize("kind", ["sf", "rpf", "tpf"])
+def test_active_sampling_rejects_budget_above_n_samples(kind):
+    n_samples = len(_synthetic_case()[1])
+    with pytest.raises(ValueError, match="0 <= n_init <= budget <= n_samples"):
+        _run_active(kind, budget=n_samples + 1)
+
+
+@pytest.mark.parametrize("kind", ["sf", "rpf", "tpf"])
+@pytest.mark.parametrize(("budget", "n_init"), [(0, 0), (12, 12)])
+def test_active_sampling_accepts_budget_boundaries(kind, budget, n_init):
+    result = _run_active(kind, budget=budget, n_init=n_init)
+
+    assert len(result.selected_indices) == budget
+    assert len(set(result.selected_indices)) == budget
+    assert len(result.estimates) == budget

--- a/tests/test_bq_sampling.py
+++ b/tests/test_bq_sampling.py
@@ -1,0 +1,178 @@
+# Copyright 2026 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for Bayesian Quadrature sampling-budget semantics."""
+
+import numpy as np
+import pytest
+
+from proeval.sampler.bq import (
+    _bq_active_sampling,
+    _bq_encoder_random_sampling,
+    _bq_encoder_sampling,
+    _bq_matern_active_sampling,
+    _bq_matern_random_sampling,
+    _bq_random_sampling,
+    _get_posterior,
+)
+
+
+def _synthetic_case():
+    rng = np.random.default_rng(0)
+    n_samples = 12
+    features = rng.normal(size=(4, n_samples))
+    labels = np.array([0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1], dtype=float)
+    prior_mean = np.linspace(0.25, 0.55, n_samples)
+    prior_cov = np.eye(n_samples)
+    return features, labels, prior_mean, prior_cov
+
+
+class _DummyLinearEncoder:
+    kernel_type = "linear"
+
+    def __init__(self, torch):
+        self._anchor = torch.nn.Parameter(torch.zeros(()))
+
+    def parameters(self):
+        yield self._anchor
+
+
+def _run_active(kind, budget, n_init=0):
+    features, labels, prior_mean, prior_cov = _synthetic_case()
+    np.random.seed(7)
+
+    if kind == "sf":
+        return _bq_active_sampling(
+            features,
+            labels,
+            prior_mean,
+            prior_cov,
+            budget=budget,
+            n_init=n_init,
+        )
+    if kind == "rpf":
+        return _bq_matern_active_sampling(
+            features.T,
+            labels,
+            prior_mean,
+            budget=budget,
+            n_init=n_init,
+        )
+
+    torch = pytest.importorskip("torch")
+    return _bq_encoder_sampling(
+        features.T,
+        labels,
+        prior_mean,
+        0.3,
+        _DummyLinearEncoder(torch),
+        budget=budget,
+        n_init=n_init,
+    )
+
+
+def _run_random(kind, budget):
+    features, labels, prior_mean, prior_cov = _synthetic_case()
+    np.random.seed(7)
+
+    if kind == "sf":
+        return _bq_random_sampling(
+            features,
+            labels,
+            prior_mean,
+            prior_cov,
+            budget=budget,
+        )
+    if kind == "rpf":
+        return _bq_matern_random_sampling(
+            features.T,
+            labels,
+            prior_mean,
+            budget=budget,
+        )
+
+    torch = pytest.importorskip("torch")
+    return _bq_encoder_random_sampling(
+        features.T,
+        labels,
+        prior_mean,
+        0.3,
+        _DummyLinearEncoder(torch),
+        budget=budget,
+    )
+
+
+@pytest.mark.parametrize("kind", ["sf", "rpf", "tpf"])
+@pytest.mark.parametrize("budget", [1, 5])
+def test_active_sampling_honors_budget(kind, budget):
+    result = _run_active(kind, budget)
+
+    assert len(result.selected_indices) == budget
+    assert len(set(result.selected_indices)) == budget
+    assert len(result.estimates) == budget
+    assert np.all(np.isfinite(result.estimates))
+    assert np.all(np.isfinite(result.integral_variance))
+
+
+@pytest.mark.parametrize("kind", ["sf", "rpf", "tpf"])
+def test_active_sampling_honors_budget_with_initial_samples(kind):
+    result = _run_active(kind, budget=5, n_init=2)
+
+    assert len(result.selected_indices) == 5
+    assert len(set(result.selected_indices)) == 5
+    assert len(result.estimates) == 5
+    assert np.all(np.isfinite(result.estimates))
+
+
+@pytest.mark.parametrize("kind", ["sf", "rpf", "tpf"])
+def test_active_and_random_sampling_use_same_number_of_evaluations(kind):
+    active = _run_active(kind, budget=5)
+    random = _run_random(kind, budget=5)
+
+    assert len(active.selected_indices) == 5
+    assert len(random.selected_indices) == 5
+
+
+def test_active_estimates_are_post_sample_posteriors():
+    features, labels, prior_mean, prior_cov = _synthetic_case()
+    np.random.seed(7)
+    result = _bq_active_sampling(
+        features,
+        labels,
+        prior_mean,
+        prior_cov,
+        budget=5,
+    )
+
+    first_idx = result.selected_indices[:1]
+    first_posterior, _ = _get_posterior(
+        features[:, first_idx],
+        labels[first_idx],
+        features,
+        0.3,
+        first_idx,
+        prior_mean,
+    )
+    final_posterior, _ = _get_posterior(
+        features[:, result.selected_indices],
+        labels[result.selected_indices],
+        features,
+        0.3,
+        result.selected_indices,
+        prior_mean,
+    )
+
+    assert result.estimates[0] == pytest.approx(np.mean(first_posterior))
+    assert result.estimates[-1] == pytest.approx(np.mean(final_posterior))
+    np.testing.assert_allclose(result.posterior_mean, final_posterior)


### PR DESCRIPTION
## Summary

Active BQ samplers currently record the zero-sample prior as the first estimate, so a nominal budget of `N` acquires only `N - 1` target evaluations.

This change aligns the active SF, RPF, and TPF sampling paths with the public `budget` semantics and the corresponding random samplers: each entry in `estimates` now represents the posterior after an actual target evaluation.

The zero-evaluation state remains available separately through `prior_mean`.

## Reproduction

On current `main`:

```text
requested budget = 1
SF    active=0
RPF   active=0
TPF   active=0

requested budget = 5
SF    active=4
RPF   active=4
TPF   active=4
```

The bundled SVAMP example similarly reports:

```text
Samples used: 49 / 700
```

with `budget=50`.

After this change:

```text
requested budget = 1
SF    active=1  random=1
RPF   active=1  random=1
TPF   active=1  random=1

requested budget = 5
SF    active=5  random=5
RPF   active=5  random=5
TPF   active=5  random=5
```

and the bundled SVAMP example reports:

```text
Samples used: 50 / 700
```

## Change

- acquire the next target point before storing each active-sampling estimate;
- preserve the zero-sample state through `prior_mean`;
- preserve the requested number of estimates;
- make `selected_indices` contain the full requested evaluation budget;
- handle `n_init > 0` consistently across SF, RPF, and TPF.

## Validation

- regression tests for SF, RPF, and TPF at budgets 1 and 5;
- active/random budget-count consistency;
- `n_init=2` coverage;
- posterior consistency checks;
- 100-seed stress test across all three active sampler families;
- bundled SVAMP before/after reproduction;
- full test suite: 38 passed;
- package compile and build succeeded.

The modified `bq.py` has the same pre-existing Ruff diagnostics as upstream; this change introduces no additional Ruff diagnostics, and the new regression test file passes Ruff.
